### PR TITLE
Remove items from the queue that have already been played

### DIFF
--- a/components/Playlist/Playlist.tsx
+++ b/components/Playlist/Playlist.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import QueueItem from "./QueueItem";
 import NowPlaying from "./NowPlaying";
 import useNowPlayingTrack from "@/hooks/useNowPlayingTrack";
+import { filterUpcomingTracks } from "@/lib/utils";
 
 interface IPlaylistProps {
   tracks: TrackItem[];
@@ -10,6 +11,8 @@ interface IPlaylistProps {
 
 export const Playlist: React.FC<IPlaylistProps> = ({ tracks }) => {
   const { data: nowPlaying } = useNowPlayingTrack();
+  const currentTrackId = nowPlaying?.item?.id ?? null;
+  const upcomingTracks = filterUpcomingTracks(tracks, currentTrackId);
 
   return (
     <div className="w-full">
@@ -19,11 +22,11 @@ export const Playlist: React.FC<IPlaylistProps> = ({ tracks }) => {
 
           <div className="flex flex-col p-5">
             <div className="border-b pb-1 flex justify-between items-center mb-2">
-              <span className=" text-base font-semibold uppercase text-gray-700">
-                QUEUE
+              <span className="text-base font-semibold uppercase text-gray-700">
+                UPCOMING TRACKS
               </span>
             </div>
-            {tracks.map((track) => (
+            {upcomingTracks.map((track) => (
               <QueueItem key={track.track.id} track={track} />
             ))}
           </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,20 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { TrackItem } from "@/shared/types"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const filterUpcomingTracks = (
+  playlistTracks: TrackItem[],
+  currentTrackId: string | null
+): TrackItem[] => {
+  if (!currentTrackId) return playlistTracks; // If no track is playing, return full list
+
+  const index = playlistTracks.findIndex(track => track.track.id === currentTrackId);
+  
+  if (index === -1) return playlistTracks; // If current track isn't found, return full list
+
+  return playlistTracks.slice(index + 1); // Return only upcoming songs
+};


### PR DESCRIPTION
Note a couple of known issue are likely to occur with this change.   This won't work if the playlist is on shuffle due the using of a split.  If the playlist is empty it or nothing is playing the entire playlist will be shown.