### PR TITLE
Refactor playback state check in refresh-site API to simplify logging

### DIFF
--- a/app/api/refresh-site/route.ts
+++ b/app/api/refresh-site/route.ts
@@ -26,9 +26,9 @@ export async function GET(request: Request) {
           method: 'GET',
         });
 
-        // If there's an active device and it's currently playing
-        if (playbackState?.device?.id && playbackState.is_playing) {
-          console.log('Found active playing device, reinitializing playback');
+        // If there's an active device
+        if (playbackState?.device?.id) {
+          console.log('Found active device, reinitializing playback');
           
           // Store current state before pausing
           const currentTrackUri = playbackState.item?.uri;


### PR DESCRIPTION
Updated the condition for checking active devices in the playback state. The log message now reflects the presence of an active device without checking if it's currently playing, streamlining the logic for reinitializing playback.